### PR TITLE
Swap local models for Azure OpenAI

### DIFF
--- a/src/azure_client.py
+++ b/src/azure_client.py
@@ -1,0 +1,42 @@
+import os
+from typing import List
+from openai import AzureOpenAI
+
+AZURE_API_KEY = os.getenv("AZURE_API_KEY")
+AZURE_ENDPOINT = os.getenv("AZURE_ENDPOINT")
+AZURE_DEPLOYMENT_NAME = os.getenv("AZURE_DEPLOYMENT_NAME")
+AZURE_API_VERSION = os.getenv("AZURE_API_VERSION", "2023-05-15")
+
+def _get_client() -> AzureOpenAI:
+    return AzureOpenAI(
+        api_key=AZURE_API_KEY,
+        azure_endpoint=AZURE_ENDPOINT,
+        api_version=AZURE_API_VERSION,
+    )
+
+
+def chat_completion(prompt: str) -> str:
+    client = _get_client()
+    response = client.chat.completions.create(
+        model=AZURE_DEPLOYMENT_NAME,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return response.choices[0].message.content
+
+
+def get_embeddings(texts: List[str]) -> List[List[float]]:
+    client = _get_client()
+    response = client.embeddings.create(model=AZURE_DEPLOYMENT_NAME, input=texts)
+    return [d.embedding for d in response.data]
+
+from llama_index.core.base.embeddings.base import BaseEmbedding, Embedding
+
+class AzureEmbedding(BaseEmbedding):
+    def _get_text_embedding(self, text: str) -> Embedding:
+        return get_embeddings([text])[0]
+
+    def _get_query_embedding(self, query: str) -> Embedding:
+        return get_embeddings([query])[0]
+
+    def _get_text_embeddings(self, texts: List[str]) -> List[Embedding]:
+        return get_embeddings(texts)

--- a/src/contextual_retrieval/save_contextual_retrieval.py
+++ b/src/contextual_retrieval/save_contextual_retrieval.py
@@ -1,6 +1,6 @@
 from llama_index.core import SimpleDirectoryReader
-from llama_index.llms.ollama import Ollama
 from llama_index.core.node_parser import TokenTextSplitter
+from src.azure_client import chat_completion
 from .save_vectordb import save_chromadb
 from .save_bm25 import save_BM25
 
@@ -20,8 +20,7 @@ def create_and_save_db(
     CHUNK_SIZE = chunk_size
     CHUNK_OVERLAP = chunk_overlap
 
-    # Initializing LLM for contextual retrieval
-    llm = Ollama(model="gemma2:2b", request_timeout=60.0)
+    # Using Azure OpenAI for contextual retrieval
     
     # Reading documents
     reader = SimpleDirectoryReader(input_dir=DATA_DIR)
@@ -62,12 +61,12 @@ def create_and_save_db(
         prompt = template.format(WHOLE_DOCUMENT=original_document_content, 
                                  CHUNK_CONTENT=content_body)
         
-        llm_response = llm.complete(prompt)
-        contextual_text = llm_response.text + content_body
+        response_text = chat_completion(prompt)
+        contextual_text = response_text + content_body
         nodes[idx].text = contextual_text
         idx += 1
 
-        print(f'Context response from LLM => {llm_response}\n For given text chunk => {content_body}')
+        print(f'Context response from LLM => {response_text}\n For given text chunk => {content_body}')
     
     vectordb_name = db_name + "_vectordb"
     bm25db_name = db_name + "_bm25"

--- a/src/contextual_retrieval/save_vectordb.py
+++ b/src/contextual_retrieval/save_vectordb.py
@@ -1,6 +1,6 @@
 from llama_index.vector_stores.chroma import ChromaVectorStore
 from llama_index.core import StorageContext
-from llama_index.embeddings.huggingface import HuggingFaceEmbedding
+from src.azure_client import AzureEmbedding
 from llama_index.core import VectorStoreIndex
 import chromadb
 import os
@@ -13,7 +13,7 @@ def save_chromadb(nodes: list,
     print("-:-:-:- ChromaDB [Vector Database] creating ... -:-:-:-")
 
     # Embedding Model
-    embed_model = HuggingFaceEmbedding(model_name="BAAI/bge-base-en-v1.5")
+    embed_model = AzureEmbedding()
 
     # Path to save the database file
     save_pth = os.path.join(save_dir, db_name)

--- a/src/db/read_db.py
+++ b/src/db/read_db.py
@@ -1,5 +1,5 @@
 from llama_index.core import VectorStoreIndex
-from llama_index.embeddings.huggingface import HuggingFaceEmbedding
+from src.azure_client import AzureEmbedding
 from llama_index.vector_stores.chroma import ChromaVectorStore
 from llama_index.retrievers.bm25 import BM25Retriever
 from llama_index.core import QueryBundle
@@ -22,7 +22,7 @@ class SemanticBM25Retriever(BaseRetriever):
         BM25_DB_PATH = os.getenv("BM25_DB_PATH")
 
         # Embedding Model
-        self._embed_model = HuggingFaceEmbedding(model_name="BAAI/bge-base-en-v1.5")
+        self._embed_model = AzureEmbedding()
 
         # Read stored Vector Database
         self._vectordb = chromadb.PersistentClient(path=VECTOR_DB_PATH)


### PR DESCRIPTION
## Summary
- add `azure_client.py` helper for Azure OpenAI chat and embeddings
- use `chat_completion` instead of Ollama for contextual retrieval
- call Azure embeddings when saving the vector DB
- update retriever to use Azure embeddings

## Testing
- `python -m py_compile src/azure_client.py src/contextual_retrieval/save_contextual_retrieval.py src/contextual_retrieval/save_vectordb.py src/db/read_db.py`

------
https://chatgpt.com/codex/tasks/task_e_6870f9e6d13c832ebf4b258fa894423c