### PR TITLE
Add BASE_PATH configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+BASE_PATH="/path/to/drive"
+DATA_DIR="./data"
+SAVE_DIR="./src/db"
+VECTOR_DB_PATH="src/db/cook_book_db_vectordb"
+BM25_DB_PATH="src/db/cook_book_db_bm25"
+COLLECTION_NAME="add_collection_name"
+API_URL="http://127.0.0.1:8000/rag-chat"

--- a/README.md
+++ b/README.md
@@ -41,12 +41,15 @@ Create a directory `data` and add all the PDF's there
 mkdir data
 ```
 
-Create `.env` file and add below variables. 
+Create a `.env` file and add the following variables. `BASE_PATH` defines the
+drive or root directory you want to store all data under. Other paths are
+appended to this base location.
 ```shell
+BASE_PATH="/path/to/drive"
 DATA_DIR="./data"
 SAVE_DIR="./src/db"
-VECTOR_DB_PATH="./src/db/cook_book_db_vectordb"
-BM25_DB_PATH="./src/db/cook_book_db_bm25"
+VECTOR_DB_PATH="src/db/cook_book_db_vectordb"
+BM25_DB_PATH="src/db/cook_book_db_bm25"
 COLLECTION_NAME="add_collection_name"
 API_URL="http://127.0.0.1:8000/rag-chat"
 ```

--- a/create_save_db.py
+++ b/create_save_db.py
@@ -3,8 +3,9 @@ import os
 from dotenv import load_dotenv
 load_dotenv()
 
-data_dir = os.getenv("DATA_DIR")
-save_dir = os.getenv("SAVE_DIR")
+BASE_PATH = os.getenv("BASE_PATH", "")
+data_dir = os.path.join(BASE_PATH, os.getenv("DATA_DIR", ""))
+save_dir = os.path.join(BASE_PATH, os.getenv("SAVE_DIR", ""))
 collection_name = os.getenv("COLLECTION_NAME")
 db_name = "cook_book_db"
 

--- a/main.py
+++ b/main.py
@@ -6,7 +6,8 @@ import json
 from dotenv import load_dotenv
 load_dotenv()
 
-st.title("RAG with Contextual Retrieval")
+BASE_PATH = os.getenv("BASE_PATH", "")
+st.title(f"Chatbot Interface for Drive: {BASE_PATH}")
 st.markdown("Implemented in Llama-index 🦙")
 st.markdown("Link to the Anthropic [blog post](https://www.anthropic.com/news/contextual-retrieval)")
 

--- a/src/contextual_retrieval/save_contextual_retrieval.py
+++ b/src/contextual_retrieval/save_contextual_retrieval.py
@@ -3,18 +3,23 @@ from llama_index.core.node_parser import TokenTextSplitter
 from src.azure_client import chat_completion
 from .save_vectordb import save_chromadb
 from .save_bm25 import save_BM25
+import os
+from dotenv import load_dotenv
+load_dotenv()
 
 def create_and_save_db(
-        data_dir: str, 
-        collection_name : str, 
-        save_dir: str, 
+        data_dir: str,
+        collection_name : str,
+        save_dir: str,
         db_name: str = "default",
         chunk_size: int = 512, 
         chunk_overlap: int =20
         ) -> None:
 
-    # Path directory to data storage 
-    DATA_DIR = data_dir
+    # Path directory to data storage
+    BASE_PATH = os.getenv("BASE_PATH", "")
+    DATA_DIR = os.path.join(BASE_PATH, data_dir)
+    SAVE_DIR = os.path.join(BASE_PATH, save_dir)
 
     # Hyperparameters for text splitting
     CHUNK_SIZE = chunk_size
@@ -72,11 +77,11 @@ def create_and_save_db(
     bm25db_name = db_name + "_bm25"
     
     # Saving the Vector Database and BM25 Database
-    save_chromadb(nodes=nodes, 
-                  save_dir=save_dir, 
-                  db_name=vectordb_name, 
+    save_chromadb(nodes=nodes,
+                  save_dir=SAVE_DIR,
+                  db_name=vectordb_name,
                   collection_name=collection_name)
     
-    save_BM25(nodes=nodes, 
-              save_dir=save_dir, 
+    save_BM25(nodes=nodes,
+              save_dir=SAVE_DIR,
               db_name=bm25db_name)

--- a/src/db/read_db.py
+++ b/src/db/read_db.py
@@ -18,8 +18,9 @@ class SemanticBM25Retriever(BaseRetriever):
         self._mode = mode
 
         # Path to database directories
-        VECTOR_DB_PATH = os.getenv("VECTOR_DB_PATH")
-        BM25_DB_PATH = os.getenv("BM25_DB_PATH")
+        BASE_PATH = os.getenv("BASE_PATH", "")
+        VECTOR_DB_PATH = os.path.join(BASE_PATH, os.getenv("VECTOR_DB_PATH", ""))
+        BM25_DB_PATH = os.path.join(BASE_PATH, os.getenv("BM25_DB_PATH", ""))
 
         # Embedding Model
         self._embed_model = AzureEmbedding()


### PR DESCRIPTION
## Summary
- document `BASE_PATH` variable in README and provide `.env.example`
- use `BASE_PATH` to build database paths
- honor the new base path in indexing scripts
- show the active drive in the Streamlit UI

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6870fcb4ae68832e8a1037b17ea8b6da