### PR TITLE
Improve chunking defaults and metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ Create Python `env` and run `requirements.txt` file
 pip install -r requirements.txt
 ```
 
-Create a directory `data` and add all the PDF's there
+Create a directory `data` and add your documents here. Supported file types are
+`.pdf`, `.docx`, and `.txt`.
 ```shell
 mkdir data
 ```

--- a/src/contextual_retrieval/save_contextual_retrieval.py
+++ b/src/contextual_retrieval/save_contextual_retrieval.py
@@ -12,8 +12,8 @@ def create_and_save_db(
         collection_name : str,
         save_dir: str,
         db_name: str = "default",
-        chunk_size: int = 512, 
-        chunk_overlap: int =20
+        chunk_size: int = 500,
+        chunk_overlap: int = 50
         ) -> None:
 
     # Path directory to data storage
@@ -69,6 +69,12 @@ def create_and_save_db(
         response_text = chat_completion(prompt)
         contextual_text = response_text + content_body
         nodes[idx].text = contextual_text
+
+        metadata = node.metadata or {}
+        metadata["file_name"] = metadata.get("file_name", "")
+        metadata["section"] = idx
+        nodes[idx].metadata = metadata
+
         idx += 1
 
         print(f'Context response from LLM => {response_text}\n For given text chunk => {content_body}')


### PR DESCRIPTION
## Summary
- update defaults for `chunk_size` and `chunk_overlap`
- store extra metadata for each chunk
- document supported file types in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68710287f608832e855b5cf2bd3269aa