### PR TITLE
Add rotating file logger

### DIFF
--- a/src/logging_config.py
+++ b/src/logging_config.py
@@ -1,0 +1,25 @@
+import logging
+import os
+from logging.handlers import RotatingFileHandler
+
+
+def configure_root_logger():
+    """Configure root logger with rotating file handler."""
+    base_path = os.getenv("BASE_PATH", ".")
+    log_dir = os.path.join(base_path, "logs")
+    os.makedirs(log_dir, exist_ok=True)
+    log_file = os.path.join(log_dir, "app.log")
+    if not logging.getLogger().handlers:
+        handler = RotatingFileHandler(log_file, maxBytes=1_000_000, backupCount=3)
+        formatter = logging.Formatter(
+            "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        )
+        handler.setFormatter(formatter)
+        logging.getLogger().addHandler(handler)
+        logging.getLogger().setLevel(logging.INFO)
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Get a configured logger for the given module name."""
+    configure_root_logger()
+    return logging.getLogger(name)


### PR DESCRIPTION
## Summary
- configure rotating file logger under `BASE_PATH/logs`
- log user queries and request errors in FastAPI app
- log retrieval queries, accessed documents, and initialization errors in database layer

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'llama_index')*

------
https://chatgpt.com/codex/tasks/task_e_687103c10c54832ebec8f48b14f448a0