### PR TITLE
Return nodes in workflow result

### DIFF
--- a/app.py
+++ b/app.py
@@ -34,7 +34,9 @@ w._timeout = 120.0
 async def RAG_chat(w, query):
     retriever = await w.run(collection_name=os.getenv("COLLECTION_NAME"))
     result = await w.run(query=query, retriever=retriever)
-    async for chunk in result.async_response_gen():
+    nodes = result["nodes"]
+    answer = result["answer"]
+    async for chunk in answer.async_response_gen():
         yield chunk
 
 

--- a/src/tools/rag_workflow.py
+++ b/src/tools/rag_workflow.py
@@ -76,5 +76,5 @@ class RAGWorkflow(Workflow):
 
         response = await summarizer.asynthesize(query, nodes=ev.nodes)
 
-        return StopEvent(result=response)
+        return StopEvent(result={"answer": response, "nodes": ev.nodes})
     


### PR DESCRIPTION
## Summary
- include retrieved nodes alongside the answer
- update chat helper to access returned answer and nodes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'llama_index')*

------
https://chatgpt.com/codex/tasks/task_e_68710ddb96e4832e85a311b94ed95145