### PR TITLE
Add OpenAI client and dynamic backend selection

### DIFF
--- a/src/contextual_retrieval/save_contextual_retrieval.py
+++ b/src/contextual_retrieval/save_contextual_retrieval.py
@@ -1,11 +1,17 @@
 from llama_index.core import SimpleDirectoryReader
 from llama_index.core.node_parser import TokenTextSplitter
-from src.azure_client import chat_completion
-from .save_vectordb import save_chromadb
-from .save_bm25 import save_BM25
 import os
 from dotenv import load_dotenv
+
 load_dotenv()
+
+if os.getenv("OPENAI_API_KEY"):
+    from src.openai_client import chat_completion
+else:
+    from src.azure_client import chat_completion
+
+from .save_vectordb import save_chromadb
+from .save_bm25 import save_BM25
 
 def create_and_save_db(
         data_dir: str,

--- a/src/contextual_retrieval/save_vectordb.py
+++ b/src/contextual_retrieval/save_vectordb.py
@@ -1,9 +1,13 @@
 from llama_index.vector_stores.chroma import ChromaVectorStore
 from llama_index.core import StorageContext
-from src.azure_client import AzureEmbedding
 from llama_index.core import VectorStoreIndex
 import chromadb
 import os
+
+if os.getenv("OPENAI_API_KEY"):
+    from src.openai_client import OpenAIEmbedding as EmbeddingModel
+else:
+    from src.azure_client import AzureEmbedding as EmbeddingModel
 
 def save_chromadb(nodes: list, 
                   db_name: str, 
@@ -13,7 +17,7 @@ def save_chromadb(nodes: list,
     print("-:-:-:- ChromaDB [Vector Database] creating ... -:-:-:-")
 
     # Embedding Model
-    embed_model = AzureEmbedding()
+    embed_model = EmbeddingModel()
 
     # Path to save the database file
     save_pth = os.path.join(save_dir, db_name)

--- a/src/db/read_db.py
+++ b/src/db/read_db.py
@@ -1,5 +1,4 @@
 from llama_index.core import VectorStoreIndex
-from src.azure_client import AzureEmbedding
 from llama_index.vector_stores.chroma import ChromaVectorStore
 from llama_index.retrievers.bm25 import BM25Retriever
 from llama_index.core import QueryBundle
@@ -12,6 +11,11 @@ from typing import List
 import os
 from dotenv import load_dotenv
 from src.logging_config import get_logger
+
+if os.getenv("OPENAI_API_KEY"):
+    from src.openai_client import OpenAIEmbedding as EmbeddingModel
+else:
+    from src.azure_client import AzureEmbedding as EmbeddingModel
 
 load_dotenv()
 
@@ -30,7 +34,7 @@ class SemanticBM25Retriever(BaseRetriever):
 
         try:
             # Embedding Model
-            self._embed_model = AzureEmbedding()
+            self._embed_model = EmbeddingModel()
 
             # Read stored Vector Database
             self._vectordb = chromadb.PersistentClient(path=VECTOR_DB_PATH)

--- a/src/openai_client.py
+++ b/src/openai_client.py
@@ -1,0 +1,40 @@
+import os
+from typing import List
+from openai import OpenAI
+
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+OPENAI_CHAT_MODEL = os.getenv("OPENAI_CHAT_MODEL", "gpt-3.5-turbo")
+OPENAI_EMBEDDING_MODEL = os.getenv("OPENAI_EMBEDDING_MODEL", "text-embedding-ada-002")
+
+
+def _get_client() -> OpenAI:
+    return OpenAI(api_key=OPENAI_API_KEY)
+
+
+def chat_completion(prompt: str) -> str:
+    client = _get_client()
+    response = client.chat.completions.create(
+        model=OPENAI_CHAT_MODEL,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return response.choices[0].message.content
+
+
+def get_embeddings(texts: List[str]) -> List[List[float]]:
+    client = _get_client()
+    response = client.embeddings.create(model=OPENAI_EMBEDDING_MODEL, input=texts)
+    return [d.embedding for d in response.data]
+
+
+from llama_index.core.base.embeddings.base import BaseEmbedding, Embedding
+
+
+class OpenAIEmbedding(BaseEmbedding):
+    def _get_text_embedding(self, text: str) -> Embedding:
+        return get_embeddings([text])[0]
+
+    def _get_query_embedding(self, query: str) -> Embedding:
+        return get_embeddings([query])[0]
+
+    def _get_text_embeddings(self, texts: List[str]) -> List[Embedding]:
+        return get_embeddings(texts)


### PR DESCRIPTION
## Summary
- implement `src/openai_client.py` for non-Azure OpenAI usage
- allow `save_contextual_retrieval`, `save_vectordb`, and `read_db` to select
  between Azure and OpenAI backends based on `OPENAI_API_KEY`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880ae53d108832ea51addcbe27a7114