### PR TITLE
Limit document tokens for context prompt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pydantic>=1.10
 # llama_index==0.6.13
 llama-index-retrievers-bm25
 llama-index-vector-stores-chroma==0.4.2
+tiktoken>=0.6


### PR DESCRIPTION
## Summary
- truncate/summarize the whole document passed to the chunk context prompt
- ensure prompt stays within context window by capping allowed document tokens
- add `tiktoken` dependency for token counting

## Testing
- `pip install tiktoken>=0.6 >/tmp/pip2.log && tail -n 20 /tmp/pip2.log`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880f0b863ec832ead72ab3ac01ce7f2