### PR TITLE
Improve BM25 path handling

### DIFF
--- a/src/db/read_db.py
+++ b/src/db/read_db.py
@@ -30,6 +30,12 @@ class SemanticBM25Retriever(BaseRetriever):
         BM25_DB_PATH = os.path.join(BASE_PATH, os.getenv("BM25_DB_PATH", ""))
 
         try:
+            bm25_index_file = os.path.join(BM25_DB_PATH, "params.index.json")
+            if not (os.path.isdir(BM25_DB_PATH) and os.path.isfile(bm25_index_file)):
+                raise FileNotFoundError(
+                    f"BM25 index not found at {BM25_DB_PATH}. Run create_save_db.py to build the database."
+                )
+
             # Embedding Model
             self._embed_model = EmbeddingModel()
 

--- a/tests/test_read_db.py
+++ b/tests/test_read_db.py
@@ -1,0 +1,16 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath('.'))
+
+from src.db.read_db import SemanticBM25Retriever
+
+
+def test_missing_bm25_index(monkeypatch, tmp_path):
+    monkeypatch.setenv("BASE_PATH", str(tmp_path))
+    monkeypatch.setenv("VECTOR_DB_PATH", "vector")
+    monkeypatch.setenv("BM25_DB_PATH", "missing")
+
+    with pytest.raises(FileNotFoundError, match="BM25 index not found"):
+        SemanticBM25Retriever(collection_name="test")


### PR DESCRIPTION
## Summary
- check for BM25 index directory and file in `SemanticBM25Retriever`
- raise a helpful `FileNotFoundError` if the index is missing
- test that the custom error is raised when path is nonexistent

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cb8d2d574832eafa3977e043a84dc