### PR TITLE
feat: preserve relative file paths in document metadata

### DIFF
--- a/src/contextual_retrieval/save_contextual_retrieval.py
+++ b/src/contextual_retrieval/save_contextual_retrieval.py
@@ -37,9 +37,18 @@ def create_and_save_db(
     # Reading documents
     reader = SimpleDirectoryReader(
         input_dir=DATA_DIR,
-        file_extractor={".pdf": PyMuPDFReader()}
+        file_extractor={".pdf": PyMuPDFReader()},
+        recursive=True,
     )
     documents = reader.load_data()
+
+    for doc in documents:
+        metadata = doc.metadata or {}
+        file_path = metadata.get("file_path")
+        if file_path:
+            rel = os.path.relpath(file_path, DATA_DIR)
+            metadata["file_path"] = rel
+        doc.metadata = metadata
 
     original_document_content = ""
     for page in documents:


### PR DESCRIPTION
## Summary
- scan input directories recursively when loading documents
- store relative file paths in document metadata and keep file name metadata
- keep file path metadata when saving nodes to Chroma

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68907ba13d60832e8f13bb7fc490a7f3