### PR TITLE
Show file paths with document snippets

### DIFF
--- a/app.py
+++ b/app.py
@@ -39,7 +39,11 @@ async def RAG_chat(w, query):
     answer = result["answer"]
 
     sources: List[dict] = [
-        {"file": n.node.metadata.get("file_name"), "text": n.node.metadata.get("raw_chunk")}
+        {
+            "file": n.node.metadata.get("file_name"),
+            "path": n.node.metadata.get("file_path"),
+            "text": n.node.metadata.get("raw_chunk"),
+        }
         for n in nodes
     ]
     filenames = [os.path.basename(n.node.metadata.get("file_name", "")) for n in nodes if n.node.metadata.get("file_name")]

--- a/main.py
+++ b/main.py
@@ -74,5 +74,6 @@ with st.chat_message("assistant"):
             snippet = src.get("text", "")
             st.sidebar.markdown(f"**{doc_name}**")
             st.sidebar.write(snippet)
+            st.sidebar.caption(src.get("path", ""))
 
 st.session_state.messages.append({"role": "assistant", "content": response})


### PR DESCRIPTION
## Summary
- Include `file_path` in API responses so each source entry contains file, path, and text.
- Render document paths in the Streamlit sidebar to accompany snippet previews.
- Confirmed retrieval and RAG workflow keep node metadata intact, preserving `file_path` through to the UI.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68907fe91338832e93ceae7a8bd0d43b