### PR TITLE
Add clickable file links for RAG sources

### DIFF
--- a/main.py
+++ b/main.py
@@ -72,7 +72,11 @@ with st.chat_message("assistant"):
         for src in st.session_state["sources"]:
             doc_name = os.path.basename(src.get("file", "Document"))
             snippet = src.get("text", "")
-            st.sidebar.markdown(f"**{doc_name}**")
+            link = src.get("link", "")
+            st.sidebar.markdown(
+                f"[{doc_name}]({link})",
+                unsafe_allow_html=True,
+            )
             st.sidebar.write(snippet)
             st.sidebar.caption(src.get("path", ""))
 


### PR DESCRIPTION
## Summary
- Generate absolute `file://` URIs for retrieved sources and include them in API responses.
- Render sidebar filenames as clickable links pointing to the original documents.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891e7f08774832ea14cb66056251e7c