### PR TITLE
Add Unstructured and Tika document ingestion utilities

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -152,6 +152,7 @@ typing-inspect==0.9.0
 typing-inspection==0.4.1
 typing_extensions==4.14.1
 tzdata==2025.2
+unstructured==0.18.11
 urllib3==2.5.0
 uvicorn==0.35.0
 # uvloop==0.21.0

--- a/src/extractors/__init__.py
+++ b/src/extractors/__init__.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+"""High level document ingestion utilities."""
+
+import mimetypes
+
+from unstructured.documents.elements import Element
+
+from .tika_adapter import TikaAdapter
+from .unstructured_extractor import extract_unstructured
+
+
+def ingest_file(
+    path: str,
+    mime: str,
+    prefer: str = "unstructured",
+    tika: TikaAdapter | None = None,
+) -> list[Element]:
+    """Ingest a file using Unstructured and/or Tika."""
+    tika = tika or TikaAdapter()
+    extractors: list[str] = [prefer, "tika" if prefer == "unstructured" else "unstructured"]
+    elements: list[Element] = []
+    for extractor in extractors:
+        try:
+            if extractor == "unstructured":
+                elements = extract_unstructured(path, mime)
+            else:
+                elements = tika.extract(path, mime)
+        except Exception:
+            elements = []
+        if elements:
+            break
+    return [el for el in elements if getattr(el, "text", "").strip()]
+
+
+def load_documents(paths: list[str]) -> list[Element]:
+    """Load and normalize documents from a list of file paths."""
+    tika = TikaAdapter()
+    all_elements: list[Element] = []
+    for path in paths:
+        mime, _ = mimetypes.guess_type(path)
+        if not mime:
+            continue
+        elements = ingest_file(path, mime, tika=tika)
+        for el in elements:
+            if hasattr(el, "text") and isinstance(el.text, str):
+                el.text = el.text.strip()
+            all_elements.append(el)
+    return all_elements
+
+
+__all__ = ["TikaAdapter", "extract_unstructured", "ingest_file", "load_documents"]

--- a/src/extractors/tika_adapter.py
+++ b/src/extractors/tika_adapter.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+"""Adapter for interacting with an Apache Tika server."""
+
+import os
+from typing import List
+
+import requests
+from unstructured.documents.elements import Element, Text
+
+
+class TikaAdapter:
+    """Client for Apache Tika's ``/rmeta/text`` endpoint."""
+
+    def __init__(self, url: str | None = None) -> None:
+        self.url = url or os.environ.get("TIKA_URL", "http://localhost:9998")
+
+    def extract(self, path: str, mime: str) -> list[Element]:
+        """Extract elements from ``path`` using Apache Tika."""
+        headers = {
+            "Content-Disposition": f'attachment; filename="{os.path.basename(path)}"',
+            "X-Tika-PDFOcrStrategy": "auto",
+            "X-Tika-WriteLimit": "-1",
+            "X-Tika-MaxEmbeddedResources": "1000",
+            "Accept": "application/json",
+            "Content-Type": mime,
+        }
+        with open(path, "rb") as f:
+            response = requests.put(
+                f"{self.url}/rmeta/text",
+                headers=headers,
+                data=f.read(),
+                timeout=60,
+            )
+        response.raise_for_status()
+        data = response.json()
+        elements: List[Element] = []
+        for item in data:
+            content = item.get("X-TIKA:content") or item.get("content")
+            if content:
+                elements.append(Text(content.strip()))
+        return elements

--- a/src/extractors/unstructured_extractor.py
+++ b/src/extractors/unstructured_extractor.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+"""Utilities for extracting documents using the Unstructured library."""
+
+from typing import Callable, Dict
+
+from unstructured.documents.elements import Element
+from unstructured.partition.docx import partition_docx
+from unstructured.partition.pdf import partition_pdf
+from unstructured.partition.pptx import partition_pptx
+from unstructured.partition.xlsx import partition_xlsx
+
+
+_PARTITIONERS: Dict[str, Callable[..., list[Element]]] = {
+    "application/pdf": partition_pdf,
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation": partition_pptx,
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document": partition_docx,
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": partition_xlsx,
+}
+
+
+def extract_unstructured(path: str, mime: str) -> list[Element]:
+    """Extract elements from ``path`` using Unstructured.
+
+    Parameters
+    ----------
+    path: str
+        The path to the file to extract.
+    mime: str
+        The MIME type for the file.
+
+    Returns
+    -------
+    list[Element]
+        The extracted elements.
+    """
+    partitioner = _PARTITIONERS.get(mime)
+    if partitioner is None:
+        raise ValueError(f"Unsupported MIME type: {mime}")
+    return partitioner(filename=path)


### PR DESCRIPTION
## Summary
- implement Unstructured based extractor for PDF, PPTX, DOCX, and XLSX files
- add Tika adapter and file ingestion helpers with fallback logic
- expose load_documents helper and add unstructured dependency

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b46f246e8832e8ccf3422703ae1a9