### PR TITLE
Add Tika ingestion test for RTF files

### DIFF
--- a/tests/data/sample.rtf
+++ b/tests/data/sample.rtf
@@ -1,0 +1,3 @@
+{\rtf1\ansi
+This is a sample RTF fixture for Tika.
+}


### PR DESCRIPTION
## Summary
- add RTF fixture for ingestion tests
- test ingest_file uses Tika when prefer="tika"

## Testing
- `pytest tests/test_tika_adapter.py::test_ingest_file_uses_tika_for_rtf -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a486e31040832e9c58ee5274b324af