### PR TITLE
docs: mention pptx and xlsx ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This project demonstrates contextual retrieval as described by Anthropic. Docume
 4. **Prepare your documents**
    ```bash
    mkdir data
-   # add .pdf, .docx or .txt files inside this folder
+    # add .pdf, .docx, .pptx, .xlsx or .txt files inside this folder
    ```
 
 5. **Configure environment variables**
@@ -45,6 +45,7 @@ This project demonstrates contextual retrieval as described by Anthropic. Docume
    ```bash
    python create_save_db.py
    ```
+   This command ingests any files placed in `DATA_DIR`, including PowerPoint and Excel documents. See [`tests/test_ingestion_office.py`](tests/test_ingestion_office.py) for an example of validating `.pptx` and `.xlsx` ingestion.
 
 7. **Start services**
    ```bash


### PR DESCRIPTION
## Summary
- document support for .pptx and .xlsx files during data preparation
- clarify that `create_save_db.py` ingests all files in `DATA_DIR` and reference office ingestion tests

## Testing
- `pytest tests/test_ingestion_office.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a59e3dfaec832eb6e66acfbb85ebd1